### PR TITLE
feat: 파서 세션 관리 및 취소 기능 추가

### DIFF
--- a/background.js
+++ b/background.js
@@ -59,8 +59,8 @@ For multiple events:
 
 Important: Always respond in array format, and each event must contain complete information independently.`,
   // 성능 최적화를 위한 파라미터 조정
-  TEMPERATURE: 0.4,  
-  MAX_TOKENS: 200,  
+  TEMPERATURE: 0.4,
+  MAX_TOKENS: 200,
   // 캐싱 설정
   ENABLE_CACHE: true,
   CACHE_DURATION: 5 * 60 * 1000, // 5분
@@ -275,7 +275,7 @@ class ResponseCache {
   constructor() {
     this.cache = new Map();
   }
-  
+
   // 캐시 키 생성 (텍스트 해시만 - 시간대는 마지막에 덮어쓰기)
   generateKey(text) {
     // 간단한 해시 함수
@@ -287,52 +287,52 @@ class ResponseCache {
     }
     return hash.toString();
   }
-  
+
   // 캐시에서 응답 가져오기
   get(text) {
     if (!CONFIG.ENABLE_CACHE) return null;
-    
+
     const key = this.generateKey(text);
     const cached = this.cache.get(key);
-    
+
     if (cached && (Date.now() - cached.timestamp) < CONFIG.CACHE_DURATION) {
       console.log('🚀 캐시에서 응답 반환:', key);
       return cached.data;
     }
-    
+
     // 만료된 캐시 제거
     if (cached) {
       this.cache.delete(key);
     }
-    
+
     return null;
   }
-  
+
   // 캐시에 응답 저장
   set(text, data) {
     if (!CONFIG.ENABLE_CACHE) return;
-    
+
     const key = this.generateKey(text);
     this.cache.set(key, {
       data: data,
       timestamp: Date.now()
     });
-    
+
     console.log('💾 응답 캐시에 저장:', key);
-    
+
     // 캐시 크기 제한 (최대 50개)
     if (this.cache.size > 50) {
       const firstKey = this.cache.keys().next().value;
       this.cache.delete(firstKey);
     }
   }
-  
+
   // 캐시 클리어
   clear() {
     this.cache.clear();
     console.log('🗑️ 응답 캐시 클리어됨');
   }
-  
+
   // 캐시 통계
   getStats() {
     return {
@@ -345,6 +345,9 @@ class ResponseCache {
 
 // 전역 캐시 인스턴스
 const responseCache = new ResponseCache();
+
+// 활성 파서 세션 관리 (취소 기능용)
+const activeParsers = new Map();
 
 
 // LanguageModel 세션 관리
@@ -359,7 +362,7 @@ class LanguageModelManager {
       console.log('🔄 기존 LanguageModel 세션 재사용 (이미 다운로드됨)');
       return languageModelSession;
     }
-    
+
     // 모델 다운로드 중인 경우 대기
     if (isModelDownloading) {
       console.log('⏳ 모델 다운로드 중... 대기');
@@ -381,38 +384,38 @@ class LanguageModelManager {
         checkSession();
       });
     }
-    
+
     // 새 세션 생성
     return await this.createNewSession();
   }
-  
+
   static async createNewSession() {
     try {
       isModelDownloading = true;
       console.log('🚀 새 LanguageModel 세션 생성 중...');
-      
+
       // 모델 사용 가능성 확인
       console.log('🔍 LanguageModel availability 확인 중...');
       const availability = await LanguageModel.availability();
       console.log('📊 LanguageModel availability:', availability);
-      
+
       if (availability === 'unavailable') {
         console.error('❌ LanguageModel 사용 불가');
         throw new Error('Chrome 내장 AI 모델을 사용할 수 없습니다. Chrome 138+ 버전이 필요합니다.');
       }
-      
+
       // 모델 파라미터 가져오기
       console.log('⚙️ LanguageModel params 가져오기 중...');
       const params = await LanguageModel.params();
       console.log('📋 LanguageModel params:', params);
-      
+
       // 파라미터 유효성 검사 및 조정
       const temperature = Math.min(params.maxTemperature, Math.max(params.defaultTemperature, CONFIG.TEMPERATURE));
       const topK = Math.min(params.maxTopK, Math.max(1, params.defaultTopK));
-      
+
       console.log('🎯 AI 최적화된 파라미터:', { temperature, topK });
       console.log('📝 시스템 프롬프트 길이:', CONFIG.SYSTEM_PROMPT.length);
-      
+
       // 세션 생성 (다운로드 진행률 모니터링 포함)
       console.log('🏗️ LanguageModel 세션 생성 중...');
       languageModelSession = await LanguageModel.create({
@@ -432,11 +435,11 @@ class LanguageModelManager {
           });
         }
       });
-      
+
       isModelDownloading = false;
       console.log('✅ LanguageModel 세션 생성 완료:', languageModelSession);
       return languageModelSession;
-      
+
     } catch (error) {
       isModelDownloading = false;
       console.error('❌ LanguageModel 세션 생성 실패 - 상세 에러:', error);
@@ -446,7 +449,7 @@ class LanguageModelManager {
       throw error;
     }
   }
-  
+
   static destroySession() {
     if (languageModelSession && !languageModelSession.destroyed) {
       console.log('🗑️ LanguageModel 세션 정리');
@@ -454,17 +457,17 @@ class LanguageModelManager {
       languageModelSession = null;
     }
   }
-  
+
   static isSessionAvailable() {
     return languageModelSession && !languageModelSession.destroyed;
   }
-  
+
   // 세션 클론 생성 (새로운 대화 컨텍스트)
   static async createClonedSession() {
     if (!languageModelSession || languageModelSession.destroyed) {
       throw new Error('기본 세션이 없습니다. 먼저 getSession()을 호출하세요.');
     }
-    
+
     try {
       console.log('🔄 세션 클론 생성 중...');
       const clonedSession = await languageModelSession.clone();
@@ -475,40 +478,40 @@ class LanguageModelManager {
       throw error;
     }
   }
-  
+
   // 모델 상태 확인 함수
   static async checkModelStatus() {
     try {
       console.log('🔍 모델 상태 확인 중...');
-      
+
       // LanguageModel API 사용 가능 여부 확인
       if (typeof LanguageModel === 'undefined') {
         console.log('❌ LanguageModel API 사용 불가 (Chrome 138+ 필요)');
         return { available: false, reason: 'API_NOT_AVAILABLE' };
       }
-      
+
       // 모델 사용 가능성 확인
       const availability = await LanguageModel.availability();
       console.log('📊 모델 사용 가능성:', availability);
-      
+
       if (availability === 'unavailable') {
         console.log('❌ 모델 사용 불가');
         return { available: false, reason: 'MODEL_UNAVAILABLE' };
       }
-      
+
       // 기존 세션 확인
       if (languageModelSession && !languageModelSession.destroyed) {
         console.log('✅ 모델 이미 다운로드됨 (세션 존재)');
         return { available: true, reason: 'SESSION_EXISTS', downloaded: true };
       }
-      
+
       // 모델 파라미터 확인
       const params = await LanguageModel.params();
       console.log('⚙️ 모델 파라미터:', params);
-      
+
       console.log('📥 모델 다운로드 필요');
       return { available: true, reason: 'NEEDS_DOWNLOAD', downloaded: false, params };
-      
+
     } catch (error) {
       console.error('❌ 모델 상태 확인 실패:', error);
       return { available: false, reason: 'CHECK_FAILED', error: error.message };
@@ -519,7 +522,7 @@ class LanguageModelManager {
 // 성능 측정 유틸리티
 class PerformanceMonitor {
   static measurements = [];
-  
+
   static startMeasurement(name) {
     return {
       name,
@@ -528,11 +531,11 @@ class PerformanceMonitor {
       timestamp: Date.now()
     };
   }
-  
+
   static endMeasurement(measurement) {
     const endTime = performance.now();
     const endMemory = performance.memory ? performance.memory.usedJSHeapSize : 0;
-    
+
     const result = {
       name: measurement.name,
       executionTime: endTime - measurement.startTime,
@@ -541,33 +544,33 @@ class PerformanceMonitor {
       timestamp: measurement.timestamp,
       endTimestamp: Date.now()
     };
-    
+
     this.measurements.push(result);
     this.logMeasurement(result);
-    
+
     return result;
   }
-  
+
   static logMeasurement(result) {
     console.log(`📈 ${result.name} 성능 측정:`);
     console.log(`⏱️  실행 시간: ${result.executionTime.toFixed(2)}ms`);
     console.log(`🧠 메모리 사용량: ${(result.memoryUsed / 1024 / 1024).toFixed(2)}MB`);
     console.log(`📊 현재 총 메모리: ${(result.totalMemory / 1024 / 1024).toFixed(2)}MB`);
   }
-  
+
   static getAveragePerformance() {
     if (this.measurements.length === 0) return null;
-    
+
     const avgTime = this.measurements.reduce((sum, m) => sum + m.executionTime, 0) / this.measurements.length;
     const avgMemory = this.measurements.reduce((sum, m) => sum + m.memoryUsed, 0) / this.measurements.length;
-    
+
     return {
       averageTime: avgTime,
       averageMemory: avgMemory,
       totalMeasurements: this.measurements.length
     };
   }
-  
+
   static clearMeasurements() {
     this.measurements = [];
   }
@@ -579,12 +582,12 @@ class ProgressUpdater {
   static updateProgress(progress, stage) {
     state.processingProgress = Math.min(100, Math.max(0, progress));
     state.processingStage = stage;
-    
+
     // 모든 탭에 진행률 업데이트 전송
     chrome.tabs.query({}, (tabs) => {
       tabs.forEach(tab => {
-        chrome.tabs.sendMessage(tab.id, { 
-          action: 'updateProgress', 
+        chrome.tabs.sendMessage(tab.id, {
+          action: 'updateProgress',
           progress: state.processingProgress,
           stage: state.processingStage
         }).catch(() => {
@@ -593,7 +596,7 @@ class ProgressUpdater {
       });
     });
   }
-  
+
   static resetProgress() {
     state.processingProgress = 0;
     state.processingStage = 'idle';
@@ -604,37 +607,38 @@ class ProgressUpdater {
 class ApiService {
   static async parseTextWithLLM(eventData) {
     const measurement = PerformanceMonitor.startMeasurement('AI Text Parsing');
-    
+    const parserId = eventData.parserId;
+
     try {
       // 1. 캐시 확인
       ProgressUpdater.updateProgress(10, 'cache_check');
       const cachedResponse = responseCache.get(eventData.selectedText);
       if (cachedResponse) {
         console.log('🚀 캐시에서 즉시 반환');
-        
+
         // 캐시된 데이터에 현재 시간대 적용
-        const timezoneUpdatedResponse = Array.isArray(cachedResponse) 
+        const timezoneUpdatedResponse = Array.isArray(cachedResponse)
           ? cachedResponse.map(event => this.applyCurrentTimezone(event))
           : [this.applyCurrentTimezone(cachedResponse)];
-        
+
         // 시간대가 적용된 데이터 검증
-        const validatedCachedResponse = timezoneUpdatedResponse.map(event => 
+        const validatedCachedResponse = timezoneUpdatedResponse.map(event =>
           this.validateEventDataInCreateEvent(event, true)
         );
-        
+
         ProgressUpdater.updateProgress(100, 'complete');
         const performanceResult = PerformanceMonitor.endMeasurement(measurement);
         return validatedCachedResponse;
       }
-      
+
       // 2. Chrome의 내장 LanguageModel API 사용
       if (typeof LanguageModel !== 'undefined') {
         console.log('Chrome 내장 LanguageModel API 사용');
-        
+
         // 세션 가져오기 (클론 사용으로 새로운 대화 컨텍스트)
         ProgressUpdater.updateProgress(20, 'downloading');
         console.log('🔄 LanguageModel 세션 가져오기 시작');
-        
+
         let session;
         try {
           console.log('⏳ 세션 생성 대기 중...');
@@ -643,26 +647,33 @@ class ApiService {
           // 새로운 대화를 위한 클론 세션 생성
           session = await LanguageModelManager.createClonedSession();
           console.log('✅ 세션 클론 생성 완료:', session);
+
+          // parserId가 있으면 활성 파서 맵에 등록 (취소 기능용)
+          if (parserId) {
+            activeParsers.set(parserId, session);
+            console.log(`🔖 파서 등록: ${parserId}`);
+          }
+
           ProgressUpdater.updateProgress(40, 'parsing');
         } catch (error) {
           console.error('❌ 모델 로딩 실패 - 상세 에러:', error);
           console.error('❌ 에러 타입:', error.constructor.name);
           console.error('❌ 에러 메시지:', error.message);
           console.error('❌ 에러 스택:', error.stack);
-          
+
           throw new Error(`Chrome AI 모델 로딩에 실패했습니다: ${error.message}`);
         }
-        
+
         // 프롬프트 실행
         ProgressUpdater.updateProgress(60, 'processing');
-        
+
         // 현재 날짜 컨텍스트 추가
         const today = new Date();
         const dateContext = `Today is ${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}.`;
         const promptWithContext = `${dateContext}\n\n${eventData.selectedText}`;
-        
+
         console.log('🤖 AI 프롬프트 실행 시작:', promptWithContext);
-        
+
         let result;
         try {
           console.log('⏳ AI 응답 대기 중...');
@@ -672,34 +683,45 @@ class ApiService {
           console.log(`✅ AI 응답 받음 (${endTime - startTime}ms):`, result);
           ProgressUpdater.updateProgress(80, 'processing');
         } catch (error) {
+          // 세션이 취소된 경우 (destroyed)
+          if (session.destroyed) {
+            console.log(`🚫 파서 ${parserId}가 취소되어 작업 중단`);
+            throw new Error('PARSER_CANCELLED');
+          }
           console.error('❌ 프롬프트 실행 실패 - 상세 에러:', error);
           console.error('❌ 에러 타입:', error.constructor.name);
           console.error('❌ 에러 메시지:', error.message);
           console.error('❌ 에러 스택:', error.stack);
-          
+
           throw new Error(`AI 모델 응답 생성에 실패했습니다: ${error.message}`);
+        } finally {
+          // 파서 완료 시 맵에서 제거
+          if (parserId && activeParsers.has(parserId)) {
+            activeParsers.delete(parserId);
+            console.log(`🗑️ 파서 제거: ${parserId}`);
+          }
         }
-        
+
         console.log('📄 LanguageModel 원본 결과:', result);
         console.log('📄 결과 타입:', typeof result);
         console.log('📄 결과 길이:', result ? result.length : 0);
-        
+
         // 응답 처리
         ProgressUpdater.updateProgress(90, 'processing');
         console.log('🔄 응답 처리 시작...');
-        
+
         try {
           const processedResponse = this.processApiResponse({ choices: [{ message: { content: result } }] });
           console.log('✅ 응답 처리 완료:', processedResponse);
-          
+
           // 캐시에 저장
           responseCache.set(eventData.selectedText, processedResponse);
           console.log('💾 캐시에 저장 완료');
-          
+
           // 성능 측정 완료
           ProgressUpdater.updateProgress(100, 'complete');
           const performanceResult = PerformanceMonitor.endMeasurement(measurement);
-          
+
           return processedResponse;
         } catch (processError) {
           console.error('❌ 응답 처리 실패 - 상세 에러:', processError);
@@ -717,75 +739,75 @@ class ApiService {
       throw error;
     }
   }
-  
+
 
   // JSON 파싱 가능 여부 확인 함수
   static isJsonString(str) {
-      try {
-          JSON.parse(str);
-      } catch (e) {
-          return false;
-      }
-      return true;
+    try {
+      JSON.parse(str);
+    } catch (e) {
+      return false;
+    }
+    return true;
   }
   //응답에서 달력에 맞는 형식들 뽑아내기
   static processApiResponse(data) {
     try {
-        console.log('\n=== API 응답 처리 시작 ===');
-        console.log('1. 원본 응답 데이터:', {
-            model: data.model,
-            created: data.created,
-            usage: data.usage,
-            system_fingerprint: data.system_fingerprint
+      console.log('\n=== API 응답 처리 시작 ===');
+      console.log('1. 원본 응답 데이터:', {
+        model: data.model,
+        created: data.created,
+        usage: data.usage,
+        system_fingerprint: data.system_fingerprint
+      });
+
+      // LLM 응답 텍스트 추출 및 출력
+      const rawContent = data.choices[0].message.content;
+      console.log('\n2. LLM 원본 텍스트 응답:');
+      console.log('---시작---');
+      console.log(rawContent);
+      console.log('---끝---');
+
+      // JSON 추출 및 파싱
+      let eventInfo;
+      try {
+        // 백틱과 'json' 키워드 제거 로직
+        const jsonContent = rawContent
+          .replace(/```json\s*/g, '') // ```json 제거
+          .replace(/```\s*$/g, '')    // 끝의 ``` 제거
+          .trim();                    // 앞뒤 공백 제거
+
+        console.log('\n정제된 JSON 문자열:', jsonContent);
+
+        eventInfo = JSON.parse(jsonContent);
+        console.log('\n3. JSON 파싱 성공:', JSON.stringify(eventInfo, null, 2));
+      } catch (error) {
+
+        throw new Error('JSON 파싱에 실패했습니다. 응답 형식을 확인해주세요.');
+        //if (!this.isJsonString(rawContent)) {
+        //    throw new Error('JSON 파싱에 실패했습니다. 응답 형식이 JSON이 아닙니다.');
+        //}
+      }
+
+      // 배열 형태인지 확인하고 검증
+      if (Array.isArray(eventInfo)) {
+        console.log('\n4. 배열 형태의 이벤트들:', eventInfo.length, '개');
+        // 각 이벤트를 개별적으로 검증 (새 처리)
+        const validatedEvents = eventInfo.map((event, index) => {
+          console.log(`\n이벤트 ${index + 1} 검증 중:`, event);
+          return ApiService.validateEventDataInCreateEvent(event, false);
         });
-
-        // LLM 응답 텍스트 추출 및 출력
-        const rawContent = data.choices[0].message.content;
-        console.log('\n2. LLM 원본 텍스트 응답:');
-        console.log('---시작---');
-        console.log(rawContent);
-        console.log('---끝---');
-
-        // JSON 추출 및 파싱
-        let eventInfo;
-        try {
-            // 백틱과 'json' 키워드 제거 로직
-            const jsonContent = rawContent
-                .replace(/```json\s*/g, '') // ```json 제거
-                .replace(/```\s*$/g, '')    // 끝의 ``` 제거
-                .trim();                    // 앞뒤 공백 제거
-
-            console.log('\n정제된 JSON 문자열:', jsonContent);
-            
-            eventInfo = JSON.parse(jsonContent);
-            console.log('\n3. JSON 파싱 성공:', JSON.stringify(eventInfo, null, 2));
-        } catch (error) {
-
-            throw new Error('JSON 파싱에 실패했습니다. 응답 형식을 확인해주세요.');
-            //if (!this.isJsonString(rawContent)) {
-            //    throw new Error('JSON 파싱에 실패했습니다. 응답 형식이 JSON이 아닙니다.');
-            //}
-        }
-
-        // 배열 형태인지 확인하고 검증
-        if (Array.isArray(eventInfo)) {
-          console.log('\n4. 배열 형태의 이벤트들:', eventInfo.length, '개');
-          // 각 이벤트를 개별적으로 검증 (새 처리)
-          const validatedEvents = eventInfo.map((event, index) => {
-            console.log(`\n이벤트 ${index + 1} 검증 중:`, event);
-            return ApiService.validateEventDataInCreateEvent(event, false);
-          });
-          return validatedEvents;
-        } else {
-          // 단일 이벤트인 경우 배열로 감싸서 반환 (새 처리)
-          console.log('\n4. 단일 이벤트를 배열로 변환');
-          const validatedEvent = ApiService.validateEventDataInCreateEvent(eventInfo, false);
-          return [validatedEvent];
-        }
+        return validatedEvents;
+      } else {
+        // 단일 이벤트인 경우 배열로 감싸서 반환 (새 처리)
+        console.log('\n4. 단일 이벤트를 배열로 변환');
+        const validatedEvent = ApiService.validateEventDataInCreateEvent(eventInfo, false);
+        return [validatedEvent];
+      }
 
     } catch (error) {
-        console.error('응답 처리 중 에러:', error);
-        throw error;
+      console.error('응답 처리 중 에러:', error);
+      throw error;
     }
   }
 
@@ -793,17 +815,17 @@ class ApiService {
   static applyCurrentTimezone(eventData) {
     const currentTimezone = getUserTimezone();
     console.log('🕐 캐시 데이터에 현재 시간대 적용:', { currentTimezone, originalTimezone: eventData.start?.timeZone });
-    
+
     // 깊은 복사로 원본 데이터 보호
     const updatedEvent = JSON.parse(JSON.stringify(eventData));
 
     normalizeEventDateTimes(updatedEvent);
 
-    console.log('🕐 시간대 적용 완료:', { 
-      startTimezone: updatedEvent.start?.timeZone, 
-      endTimezone: updatedEvent.end?.timeZone 
+    console.log('🕐 시간대 적용 완료:', {
+      startTimezone: updatedEvent.start?.timeZone,
+      endTimezone: updatedEvent.end?.timeZone
     });
-    
+
     return updatedEvent;
   }
 
@@ -811,265 +833,265 @@ class ApiService {
     const logPrefix = isFromCache ? '[캐시]' : '[새처리]';
     console.log(`\n=== ${logPrefix} 이벤트 데이터 검증 시작 ===`);
     try {
-        // 1. 제목 검증
-        console.log('1. 제목 검증:', eventInfo.summary);
-        if (!eventInfo.summary) {
-            throw new Error('이벤트 제목이 탐지되지 않았습니다.');
+      // 1. 제목 검증
+      console.log('1. 제목 검증:', eventInfo.summary);
+      if (!eventInfo.summary) {
+        throw new Error('이벤트 제목이 탐지되지 않았습니다.');
+      }
+
+      // 1.5 날짜 형식 정규화 (YYYY-MM-DDTHH:mm -> YYYY-MM-DD)
+      // AI가 date 필드에 시간까지 포함하는 경우 강제로 날짜만 남김
+      if (eventInfo.start?.date && eventInfo.start.date.includes('T')) {
+        console.log('⚠️ start.date에 시간이 포함되어 있어 수정함:', eventInfo.start.date);
+        eventInfo.start.date = eventInfo.start.date.split('T')[0];
+      }
+      if (eventInfo.end?.date && eventInfo.end.date.includes('T')) {
+        console.log('⚠️ end.date에 시간이 포함되어 있어 수정함:', eventInfo.end.date);
+        eventInfo.end.date = eventInfo.end.date.split('T')[0];
+      }
+
+      // 2. 날짜/시간 형식 검증
+      let isAllDayEvent = !!(eventInfo.start?.date && eventInfo.end?.date);
+      let isTimeSpecificEvent = !!(eventInfo.start?.dateTime && eventInfo.end?.dateTime);
+      const hasOnlyStartTime = !!(eventInfo.start?.dateTime && !eventInfo.end?.dateTime);
+      const hasOnlyStartDate = !!(eventInfo.start?.date && !eventInfo.end);
+      const hasStartTimeButEndDate = !!(eventInfo.start?.dateTime && eventInfo.end?.date && !eventInfo.end?.dateTime);
+      const hasStartDateButEndTime = !!(eventInfo.start?.date && !eventInfo.start?.dateTime && eventInfo.end?.dateTime);
+
+      console.log('2. 이벤트 타입:', {
+        isAllDayEvent,
+        isTimeSpecificEvent,
+        hasOnlyStartTime,
+        hasOnlyStartDate,
+        hasStartTimeButEndDate,
+        hasStartDateButEndTime,
+        start: eventInfo.start,
+        end: eventInfo.end
+      });
+
+      // 2.5 혼합된 형식 처리 (start=date, end=dateTime 또는 그 반대)
+      if (hasStartDateButEndTime) {
+        console.log('⚠️ start는 date, end는 dateTime - start를 dateTime으로 변환');
+        // start.date를 00:00:00으로 시작하는 dateTime으로 변환
+        const startDateTime = `${eventInfo.start.date}T00:00:00`;
+        const userTz = getUserTimezone();
+        eventInfo.start = {
+          dateTime: ensureDateTimeHasOffset(startDateTime, userTz),
+          timeZone: userTz
+        };
+        isTimeSpecificEvent = true;
+        isAllDayEvent = false;
+      }
+
+      // 시작 시간만 있고 종료 시간이 없는 경우 1시간짜리 이벤트로 설정
+      if (hasOnlyStartTime) {
+        console.log('3. 시작 시간만 있는 경우 - 1시간짜리 이벤트로 자동 설정');
+        const startDateTimeStr = eventInfo.start.dateTime;
+
+        // ISO 8601 형식 파싱: YYYY-MM-DDTHH:mm:ss+TZ 또는 YYYY-MM-DDTHH:mm:ss
+        const match = startDateTimeStr.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-]\d{2}:\d{2}|Z)?$/);
+        if (!match) {
+          throw new Error('유효하지 않은 시작 시간 형식입니다.');
         }
 
-        // 1.5 날짜 형식 정규화 (YYYY-MM-DDTHH:mm -> YYYY-MM-DD)
-        // AI가 date 필드에 시간까지 포함하는 경우 강제로 날짜만 남김
-        if (eventInfo.start?.date && eventInfo.start.date.includes('T')) {
-            console.log('⚠️ start.date에 시간이 포함되어 있어 수정함:', eventInfo.start.date);
-            eventInfo.start.date = eventInfo.start.date.split('T')[0];
-        }
-        if (eventInfo.end?.date && eventInfo.end.date.includes('T')) {
-            console.log('⚠️ end.date에 시간이 포함되어 있어 수정함:', eventInfo.end.date);
-            eventInfo.end.date = eventInfo.end.date.split('T')[0];
+        const [, year, month, day, hours, minutes, seconds, existingOffset] = match;
+        const userTz = getUserTimezone();
+        const secondValue = seconds || '00';
+
+        if (!existingOffset) {
+          eventInfo.start.dateTime = ensureDateTimeHasOffset(startDateTimeStr, userTz, {
+            year,
+            month,
+            day,
+            hour: hours,
+            minute: minutes,
+            second: secondValue
+          });
         }
 
-        // 2. 날짜/시간 형식 검증
-        let isAllDayEvent = !!(eventInfo.start?.date && eventInfo.end?.date);
-        let isTimeSpecificEvent = !!(eventInfo.start?.dateTime && eventInfo.end?.dateTime);
-        const hasOnlyStartTime = !!(eventInfo.start?.dateTime && !eventInfo.end?.dateTime);
-        const hasOnlyStartDate = !!(eventInfo.start?.date && !eventInfo.end);
-        const hasStartTimeButEndDate = !!(eventInfo.start?.dateTime && eventInfo.end?.date && !eventInfo.end?.dateTime);
-        const hasStartDateButEndTime = !!(eventInfo.start?.date && !eventInfo.start?.dateTime && eventInfo.end?.dateTime);
-        
-        console.log('2. 이벤트 타입:', {
-            isAllDayEvent,
-            isTimeSpecificEvent,
-            hasOnlyStartTime,
-            hasOnlyStartDate,
-            hasStartTimeButEndDate,
-            hasStartDateButEndTime,
-            start: eventInfo.start,
-            end: eventInfo.end
+        // 시간을 1시간 증가 (자리올림 처리)
+        let endHours = parseInt(hours);
+        let endDay = parseInt(day);
+
+        endHours += 1;
+        if (endHours >= 24) {
+          endHours = 0;
+          endDay += 1;
+        }
+
+        const paddedEndDay = String(endDay).padStart(2, '0');
+        const paddedEndHour = String(endHours).padStart(2, '0');
+        const naiveEndDateTimeStr = `${year}-${month}-${paddedEndDay}T${paddedEndHour}:${minutes}:${secondValue}`;
+        const normalizedEnd = ensureDateTimeHasOffset(naiveEndDateTimeStr, userTz, {
+          year,
+          month,
+          day: paddedEndDay,
+          hour: paddedEndHour,
+          minute: minutes,
+          second: secondValue
         });
 
-        // 2.5 혼합된 형식 처리 (start=date, end=dateTime 또는 그 반대)
-        if (hasStartDateButEndTime) {
-            console.log('⚠️ start는 date, end는 dateTime - start를 dateTime으로 변환');
-            // start.date를 00:00:00으로 시작하는 dateTime으로 변환
-            const startDateTime = `${eventInfo.start.date}T00:00:00`;
-            const userTz = getUserTimezone();
-            eventInfo.start = {
-                dateTime: ensureDateTimeHasOffset(startDateTime, userTz),
-                timeZone: userTz
-            };
-            isTimeSpecificEvent = true;
-            isAllDayEvent = false;
+        eventInfo.end = {
+          dateTime: normalizedEnd,
+          timeZone: userTz
+        };
+
+        console.log('   시작 시간:', eventInfo.start.dateTime);
+        console.log('   자동 설정된 종료 시간:', normalizedEnd);
+
+        isTimeSpecificEvent = true;
+        isAllDayEvent = false;
+      }
+
+      // 시작 시간은 있지만 종료는 날짜만 있는 경우 - 시작 시간에 맞춰 1시간짜리 이벤트로 설정
+      if (hasStartTimeButEndDate) {
+        console.log('3. 시작 시간은 있지만 종료는 날짜만 있는 경우 - 시작 시간에 맞춰 1시간짜리 이벤트로 설정');
+        const startDateTimeStr = eventInfo.start.dateTime;
+
+        // ISO 8601 형식 파싱: YYYY-MM-DDTHH:mm:ss+TZ 또는 YYYY-MM-DDTHH:mm:ss
+        const match = startDateTimeStr.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-]\d{2}:\d{2}|Z)?$/);
+        if (!match) {
+          throw new Error('유효하지 않은 시작 시간 형식입니다.');
         }
 
-        // 시작 시간만 있고 종료 시간이 없는 경우 1시간짜리 이벤트로 설정
-        if (hasOnlyStartTime) {
-            console.log('3. 시작 시간만 있는 경우 - 1시간짜리 이벤트로 자동 설정');
-            const startDateTimeStr = eventInfo.start.dateTime;
+        const [, year, month, day, hours, minutes, seconds, existingOffset] = match;
+        const userTz = getUserTimezone();
+        const secondValue = seconds || '00';
 
-            // ISO 8601 형식 파싱: YYYY-MM-DDTHH:mm:ss+TZ 또는 YYYY-MM-DDTHH:mm:ss
-            const match = startDateTimeStr.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-]\d{2}:\d{2}|Z)?$/);
-            if (!match) {
-                throw new Error('유효하지 않은 시작 시간 형식입니다.');
-            }
-
-            const [, year, month, day, hours, minutes, seconds, existingOffset] = match;
-            const userTz = getUserTimezone();
-            const secondValue = seconds || '00';
-
-            if (!existingOffset) {
-                eventInfo.start.dateTime = ensureDateTimeHasOffset(startDateTimeStr, userTz, {
-                    year,
-                    month,
-                    day,
-                    hour: hours,
-                    minute: minutes,
-                    second: secondValue
-                });
-            }
-
-            // 시간을 1시간 증가 (자리올림 처리)
-            let endHours = parseInt(hours);
-            let endDay = parseInt(day);
-
-            endHours += 1;
-            if (endHours >= 24) {
-                endHours = 0;
-                endDay += 1;
-            }
-
-            const paddedEndDay = String(endDay).padStart(2, '0');
-            const paddedEndHour = String(endHours).padStart(2, '0');
-            const naiveEndDateTimeStr = `${year}-${month}-${paddedEndDay}T${paddedEndHour}:${minutes}:${secondValue}`;
-            const normalizedEnd = ensureDateTimeHasOffset(naiveEndDateTimeStr, userTz, {
-                year,
-                month,
-                day: paddedEndDay,
-                hour: paddedEndHour,
-                minute: minutes,
-                second: secondValue
-            });
-
-            eventInfo.end = {
-                dateTime: normalizedEnd,
-                timeZone: userTz
-            };
-
-            console.log('   시작 시간:', eventInfo.start.dateTime);
-            console.log('   자동 설정된 종료 시간:', normalizedEnd);
-
-            isTimeSpecificEvent = true;
-            isAllDayEvent = false;
+        if (!existingOffset) {
+          eventInfo.start.dateTime = ensureDateTimeHasOffset(startDateTimeStr, userTz, {
+            year,
+            month,
+            day,
+            hour: hours,
+            minute: minutes,
+            second: secondValue
+          });
         }
 
-        // 시작 시간은 있지만 종료는 날짜만 있는 경우 - 시작 시간에 맞춰 1시간짜리 이벤트로 설정
-        if (hasStartTimeButEndDate) {
-            console.log('3. 시작 시간은 있지만 종료는 날짜만 있는 경우 - 시작 시간에 맞춰 1시간짜리 이벤트로 설정');
-            const startDateTimeStr = eventInfo.start.dateTime;
+        // 시간을 1시간 증가 (자리올림 처리)
+        let endHours = parseInt(hours);
+        let endDay = parseInt(day);
 
-            // ISO 8601 형식 파싱: YYYY-MM-DDTHH:mm:ss+TZ 또는 YYYY-MM-DDTHH:mm:ss
-            const match = startDateTimeStr.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})([+-]\d{2}:\d{2}|Z)?$/);
-            if (!match) {
-                throw new Error('유효하지 않은 시작 시간 형식입니다.');
-            }
-
-            const [, year, month, day, hours, minutes, seconds, existingOffset] = match;
-            const userTz = getUserTimezone();
-            const secondValue = seconds || '00';
-
-            if (!existingOffset) {
-                eventInfo.start.dateTime = ensureDateTimeHasOffset(startDateTimeStr, userTz, {
-                    year,
-                    month,
-                    day,
-                    hour: hours,
-                    minute: minutes,
-                    second: secondValue
-                });
-            }
-
-            // 시간을 1시간 증가 (자리올림 처리)
-            let endHours = parseInt(hours);
-            let endDay = parseInt(day);
-
-            endHours += 1;
-            if (endHours >= 24) {
-                endHours = 0;
-                endDay += 1;
-            }
-
-            const paddedEndDay = String(endDay).padStart(2, '0');
-            const paddedEndHour = String(endHours).padStart(2, '0');
-            const naiveEndDateTimeStr = `${year}-${month}-${paddedEndDay}T${paddedEndHour}:${minutes}:${secondValue}`;
-            const normalizedEnd = ensureDateTimeHasOffset(naiveEndDateTimeStr, userTz, {
-                year,
-                month,
-                day: paddedEndDay,
-                hour: paddedEndHour,
-                minute: minutes,
-                second: secondValue
-            });
-
-            eventInfo.end = {
-                dateTime: normalizedEnd,
-                timeZone: userTz
-            };
-
-            console.log('   시작 시간:', eventInfo.start.dateTime);
-            console.log('   자동 설정된 종료 시간:', normalizedEnd);
-
-            isTimeSpecificEvent = true;
-            isAllDayEvent = false;
+        endHours += 1;
+        if (endHours >= 24) {
+          endHours = 0;
+          endDay += 1;
         }
 
-        // 시작 날짜만 있고 종료 날짜가 없는 경우 하루종일 이벤트로 자동 설정
-        if (hasOnlyStartDate) {
-            console.log('3. 시작 날짜만 있는 경우 - 하루종일 이벤트로 자동 설정');
-            // end.date를 start.date와 동일하게 설정
-            // (API 전송 시 +1일 로직이 알아서 처리함)
-            eventInfo.end = {
-                date: eventInfo.start.date,
-                timeZone: eventInfo.start.timeZone || getUserTimezone()
-            };
-            console.log('   자동 설정된 종료 날짜:', eventInfo.end.date);
-            isAllDayEvent = true;
-            isTimeSpecificEvent = false;
+        const paddedEndDay = String(endDay).padStart(2, '0');
+        const paddedEndHour = String(endHours).padStart(2, '0');
+        const naiveEndDateTimeStr = `${year}-${month}-${paddedEndDay}T${paddedEndHour}:${minutes}:${secondValue}`;
+        const normalizedEnd = ensureDateTimeHasOffset(naiveEndDateTimeStr, userTz, {
+          year,
+          month,
+          day: paddedEndDay,
+          hour: paddedEndHour,
+          minute: minutes,
+          second: secondValue
+        });
+
+        eventInfo.end = {
+          dateTime: normalizedEnd,
+          timeZone: userTz
+        };
+
+        console.log('   시작 시간:', eventInfo.start.dateTime);
+        console.log('   자동 설정된 종료 시간:', normalizedEnd);
+
+        isTimeSpecificEvent = true;
+        isAllDayEvent = false;
+      }
+
+      // 시작 날짜만 있고 종료 날짜가 없는 경우 하루종일 이벤트로 자동 설정
+      if (hasOnlyStartDate) {
+        console.log('3. 시작 날짜만 있는 경우 - 하루종일 이벤트로 자동 설정');
+        // end.date를 start.date와 동일하게 설정
+        // (API 전송 시 +1일 로직이 알아서 처리함)
+        eventInfo.end = {
+          date: eventInfo.start.date,
+          timeZone: eventInfo.start.timeZone || getUserTimezone()
+        };
+        console.log('   자동 설정된 종료 날짜:', eventInfo.end.date);
+        isAllDayEvent = true;
+        isTimeSpecificEvent = false;
+      }
+
+      // 모든 자동 처리 완료 후 최종 검증
+      // 이 시점에서 isAllDayEvent 또는 isTimeSpecificEvent 중 하나는 반드시 true여야 함
+      if (!isAllDayEvent && !isTimeSpecificEvent) {
+        throw new Error('시작 및 종료 날짜/시간 형식이 올바르지 않습니다.');
+      }
+
+      // 두 플래그가 동시에 true이면 안 됨 (상호 배타적)
+      if (isAllDayEvent && isTimeSpecificEvent) {
+        throw new Error('이벤트는 하루종일 또는 시간 특정 중 하나여야 합니다.');
+      }
+
+      // 4. 하루종일 이벤트 처리
+      if (isAllDayEvent) {
+        console.log('4. 하루종일 이벤트 검증');
+        const startDate = new Date(eventInfo.start.date);
+        const endDate = new Date(eventInfo.end.date);
+
+        if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+          throw new Error('유효하지 않은 날짜 형식입니다.');
         }
 
-        // 모든 자동 처리 완료 후 최종 검증
-        // 이 시점에서 isAllDayEvent 또는 isTimeSpecificEvent 중 하나는 반드시 true여야 함
-        if (!isAllDayEvent && !isTimeSpecificEvent) {
-            throw new Error('시작 및 종료 날짜/시간 형식이 올바르지 않습니다.');
+        console.log('   시작일:', startDate);
+        console.log('   종료일:', endDate);
+
+        // 종료일이 시작일보다 이전이면 에러
+        if (endDate < startDate) {
+          throw new Error('종료일은 시작일보다 이전일 수 없습니다.');
         }
+      }
 
-        // 두 플래그가 동시에 true이면 안 됨 (상호 배타적)
-        if (isAllDayEvent && isTimeSpecificEvent) {
-            throw new Error('이벤트는 하루종일 또는 시간 특정 중 하나여야 합니다.');
+      // 5. attendees 처리 (문자열 배열을 description으로 변환)
+      if (eventInfo.attendees && Array.isArray(eventInfo.attendees)) {
+        console.log('5. attendees 처리 - 문자열 배열을 description으로 변환');
+
+        // attendees가 문자열 배열인지 확인
+        const hasStringArray = eventInfo.attendees.every(attendee =>
+          typeof attendee === 'string'
+        );
+
+        if (hasStringArray) {
+          const attendeesList = eventInfo.attendees.join(', ');
+          const attendeesText = `참석자: ${attendeesList}`;
+
+          // 기존 description이 있으면 추가, 없으면 새로 생성
+          if (eventInfo.description) {
+            eventInfo.description = `${eventInfo.description}\n\n${attendeesText}`;
+          } else {
+            eventInfo.description = attendeesText;
+          }
+
+          // attendees 필드 제거 (Google Calendar API에서 email이 없으면 오류 발생)
+          delete eventInfo.attendees;
+
+          console.log('   변환된 description:', eventInfo.description);
+        } else {
+          // attendees가 객체 배열이면 유효한 이메일이 있는지 확인
+          const hasValidEmails = eventInfo.attendees.every(attendee =>
+            attendee && typeof attendee === 'object' && attendee.email
+          );
+
+          if (!hasValidEmails) {
+            console.log('   유효하지 않은 attendees - 제거');
+            delete eventInfo.attendees;
+          }
         }
+      }
 
-        // 4. 하루종일 이벤트 처리
-        if (isAllDayEvent) {
-            console.log('4. 하루종일 이벤트 검증');
-            const startDate = new Date(eventInfo.start.date);
-            const endDate = new Date(eventInfo.end.date);
-            
-            if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
-                throw new Error('유효하지 않은 날짜 형식입니다.');
-            }
+      normalizeEventDateTimes(eventInfo);
 
-            console.log('   시작일:', startDate);
-            console.log('   종료일:', endDate);
-
-            // 종료일이 시작일보다 이전이면 에러
-            if (endDate < startDate) {
-                throw new Error('종료일은 시작일보다 이전일 수 없습니다.');
-            }
-        }
-
-        // 5. attendees 처리 (문자열 배열을 description으로 변환)
-        if (eventInfo.attendees && Array.isArray(eventInfo.attendees)) {
-            console.log('5. attendees 처리 - 문자열 배열을 description으로 변환');
-            
-            // attendees가 문자열 배열인지 확인
-            const hasStringArray = eventInfo.attendees.every(attendee => 
-                typeof attendee === 'string'
-            );
-            
-            if (hasStringArray) {
-                const attendeesList = eventInfo.attendees.join(', ');
-                const attendeesText = `참석자: ${attendeesList}`;
-                
-                // 기존 description이 있으면 추가, 없으면 새로 생성
-                if (eventInfo.description) {
-                    eventInfo.description = `${eventInfo.description}\n\n${attendeesText}`;
-                } else {
-                    eventInfo.description = attendeesText;
-                }
-                
-                // attendees 필드 제거 (Google Calendar API에서 email이 없으면 오류 발생)
-                delete eventInfo.attendees;
-                
-                console.log('   변환된 description:', eventInfo.description);
-            } else {
-                // attendees가 객체 배열이면 유효한 이메일이 있는지 확인
-                const hasValidEmails = eventInfo.attendees.every(attendee => 
-                    attendee && typeof attendee === 'object' && attendee.email
-                );
-                
-                if (!hasValidEmails) {
-                    console.log('   유효하지 않은 attendees - 제거');
-                    delete eventInfo.attendees;
-                }
-            }
-        }
-
-        normalizeEventDateTimes(eventInfo);
-
-        console.log(`\n✅ ${logPrefix} 최종 검증 완료된 이벤트:`, JSON.stringify(eventInfo, null, 2));
-        return eventInfo;
+      console.log(`\n✅ ${logPrefix} 최종 검증 완료된 이벤트:`, JSON.stringify(eventInfo, null, 2));
+      return eventInfo;
 
     } catch (error) {
-        console.error('\n❌ 검증 실패:', error);
-        throw error;
+      console.error('\n❌ 검증 실패:', error);
+      throw error;
     }
   }
 }
@@ -1081,7 +1103,7 @@ class CalendarService {
     try {
       // 구글 캘린더 API의 exclusive end date 처리 & dateTime 형식 정규화
       const apiEventData = { ...eventData };
-      
+
       // 1. dateTime 형식 정규화 (RFC3339 요구: YYYY-MM-DDTHH:mm:ss+offset)
       const userTimezone = getUserTimezone();
       if (apiEventData.start?.dateTime) {
@@ -1092,7 +1114,7 @@ class CalendarService {
         apiEventData.end.dateTime = ensureDateTimeHasOffset(apiEventData.end.dateTime, userTimezone);
         apiEventData.end.timeZone = userTimezone;
       }
-      
+
       // 2. 사용자가 "21일부터 23일까지"라고 말하면 23일도 포함해야 하므로
       // API 전송 직전에 end.date에 +1일을 추가 (구글 API는 end.date를 제외함)
       if (apiEventData.start?.date && apiEventData.end?.date) {
@@ -1101,7 +1123,7 @@ class CalendarService {
         apiEventData.end.date = endDate.toISOString().split('T')[0];
         console.log('📅 API 전송용 end.date +1일 조정:', eventData.end.date, '->', apiEventData.end.date);
       }
-      
+
       // Google Calendar API 호출
       const response = await fetch('https://www.googleapis.com/calendar/v3/calendars/primary/events', {
         method: 'POST',
@@ -1154,7 +1176,7 @@ class CalendarService {
 class MessageHandler {
   static async handleMessage(request, sender, sendResponse) {
     console.log('Received message:', request);
-    
+
     switch (request.action) {
       case 'getSelectedText':
         sendResponse({
@@ -1162,7 +1184,7 @@ class MessageHandler {
           selectedText: state.selectedText
         });
         break;
-        
+
       case 'getPerformanceStats':
         try {
           const stats = PerformanceMonitor.getAveragePerformance();
@@ -1177,7 +1199,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'clearPerformanceStats':
         try {
           PerformanceMonitor.clearMeasurements();
@@ -1192,7 +1214,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'destroyLanguageModelSession':
         try {
           LanguageModelManager.destroySession();
@@ -1207,7 +1229,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'getLanguageModelStatus':
         try {
           const isAvailable = LanguageModelManager.isSessionAvailable();
@@ -1223,7 +1245,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'checkModelStatus':
         try {
           const status = await LanguageModelManager.checkModelStatus();
@@ -1238,7 +1260,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'getCacheStats':
         try {
           const stats = responseCache.getStats();
@@ -1253,7 +1275,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'clearCache':
         try {
           responseCache.clear();
@@ -1268,26 +1290,49 @@ class MessageHandler {
           });
         }
         break;
-        
-        
+
+      case 'cancelParsing':
+        try {
+          const { parserId } = request;
+          console.log(`🚫 파싱 취소 요청: ${parserId}`);
+
+          if (parserId && activeParsers.has(parserId)) {
+            const session = activeParsers.get(parserId);
+            if (session && !session.destroyed) {
+              session.destroy();
+              console.log(`✅ 파서 세션 종료: ${parserId}`);
+            }
+            activeParsers.delete(parserId);
+            sendResponse({ success: true, message: '파싱이 취소되었습니다.' });
+          } else {
+            console.log(`⚠️ 파서를 찾을 수 없음: ${parserId}`);
+            sendResponse({ success: false, error: '파서를 찾을 수 없습니다.' });
+          }
+        } catch (error) {
+          console.error('❌ 파싱 취소 에러:', error);
+          sendResponse({ success: false, error: error.message });
+        }
+        break;
+
+
       case 'parseText': //텍스트 파싱만 수행, 캘린더 추가는 별도 액션에서
         try {
           console.log('🔄 parseText 요청 받음:', request.eventData);
           state.processingStatus = true;
-          
+
           // 진행률 초기화
           ProgressUpdater.resetProgress();
-          
+
           // 모델 상태 먼저 확인
           console.log('🔍 모델 상태 사전 확인...');
           const modelStatus = await LanguageModelManager.checkModelStatus();
           console.log('📊 모델 상태:', modelStatus);
-          
+
           //Api Service를 통해 처리된 데이터를 받음
           const parsedData = await ApiService.parseTextWithLLM(request.eventData);
-          
+
           console.log('✅ 파싱 완료:', parsedData);
-          
+
           sendResponse({
             success: true,
             eventData: parsedData,
@@ -1303,7 +1348,7 @@ class MessageHandler {
           state.processingStatus = false;
         }
         break;
-        
+
       case 'createCalendarEvent':
         try {
           // parseText에서 이미 검증 완료되었으므로 바로 API 호출
@@ -1319,7 +1364,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       case 'closeModal':
         // 모든 탭에서 모달 닫기 메시지 전송
         chrome.tabs.query({}, (tabs) => {
@@ -1331,7 +1376,7 @@ class MessageHandler {
         });
         sendResponse({ success: true });
         break;
-        
+
       case 'checkAuthStatus':
         try {
           // Google 인증 상태 확인
@@ -1360,20 +1405,20 @@ class MessageHandler {
       case 'getLocaleMessages':
         (async () => {
           const requestedLang = request.lang || 'en';
-          
+
           const fetchLocale = async (lang) => {
             if (!lang) return null;
             if (localeCache[lang]) {
               console.log(`[i18n] Serving locale '${lang}' from cache.`);
               return localeCache[lang];
             }
-            
+
             try {
               console.log(`[i18n] Fetching locale '${lang}'...`);
               const url = chrome.runtime.getURL(`_locales/${lang}/messages.json`);
               const response = await fetch(url);
               if (!response.ok) return null;
-              
+
               const messages = await response.json();
               localeCache[lang] = messages;
               return messages;
@@ -1416,7 +1461,7 @@ class MessageHandler {
           }
         })();
         return true; // Indicate async response
-        
+
       case 'openPopup':
         try {
           // 확장 프로그램 팝업 열기
@@ -1431,7 +1476,7 @@ class MessageHandler {
           });
         }
         break;
-        
+
       default:
         sendResponse({
           success: false,
@@ -1469,7 +1514,7 @@ chrome.runtime.onInstalled.addListener(() => {
 //오른쪽 클릭시
 chrome.contextMenus.onClicked.addListener((info, tab) => {
   console.log('🖱️ Context menu clicked:', info.menuItemId, 'on tab:', tab.id);
-  
+
   if (info.menuItemId === "createEvent") {
     console.log('📝 Create Event selected, sending message to content script');
     // 선택된 텍스트를 content script로 전송

--- a/content.js
+++ b/content.js
@@ -53,19 +53,19 @@ const COLOR_PALETTE = {
     text: '#2C3E50',
     textMuted: '#61707C',
     accent: '#E83941',
-    
+
     // 카드 색상
     cardBg: '#F6F6F6',
     dividerColor: '#E0E0E0',
     iconFill: '#303030',
     buttonBg: '#313B43',
-    
+
     // 폼 색상
     formBg: 'white',
     labelColor: '#303030',
     inputBg: '#F6F6F6',
     inputColor: '#303030',
-    
+
     // 기타
     progressBg: 'rgba(255,255,255,0.3)',
     borderColor: 'rgba(255,255,255,0.1)'
@@ -79,19 +79,19 @@ const COLOR_PALETTE = {
     text: '#e6edf3',
     textMuted: '#8b949e',
     accent: '#ff6b6b',
-    
+
     // 카드 색상
     cardBg: 'rgba(255,255,255,0.03)',
     dividerColor: 'rgba(255,255,255,0.05)',
     iconFill: '#e6edf3',
     buttonBg: '#2d333b',
-    
+
     // 폼 색상
     formBg: '#1c2128',
     labelColor: '#e6edf3',
     inputBg: 'rgba(255,255,255,0.05)',
     inputColor: '#e6edf3',
-    
+
     // 기타
     progressBg: 'rgba(255,255,255,0.1)',
     borderColor: 'rgba(255,255,255,0.05)'
@@ -202,7 +202,7 @@ function openModal() {
     createModal();
   }
   modalInstance.style.display = 'block';
-  
+
   // 애니메이션 - 우측에서 슬라이드인
   const content = modalInstance.querySelector('#modal-content');
   content.style.transform = 'translateX(100%)';
@@ -215,10 +215,10 @@ function openModal() {
 // 모달 닫기
 function closeModal() {
   if (!modalInstance) return;
-  
+
   const content = modalInstance.querySelector('#modal-content');
   content.style.transform = 'translateX(100%)';
-  
+
   setTimeout(() => {
     modalInstance.style.display = 'none';
     modalInstance.remove();
@@ -229,15 +229,15 @@ function closeModal() {
 // 결과 표시
 function displayResult(data) {
   if (!modalInstance) return;
-  
+
   const resultContent = modalInstance.querySelector('#schedule-ninja-result-content');
   const loadingIndicator = modalInstance.querySelector('#schedule-ninja-loading');
-  
+
   if (!resultContent) return;
 
   const eventsArray = data ? (Array.isArray(data) ? data : [data]) : [];
   lastParsedData = eventsArray;
-  
+
   if (eventsArray.length === 0) {
     if (loadingIndicator) loadingIndicator.style.display = 'none';
     resultContent.style.display = 'block';
@@ -256,12 +256,12 @@ function displayResult(data) {
     `;
     return;
   }
-  
+
   if (loadingIndicator) loadingIndicator.style.display = 'none';
   resultContent.style.display = 'block';
-  
+
   const colors = getColors();
-  
+
   let eventsHtml = '';
   eventsArray.forEach((eventData, index) => {
     const divider = index > 0 ? `<div style="height: 1px; background: ${colors.dividerColor}; margin: 0;"></div>` : '';
@@ -284,15 +284,15 @@ function displayResult(data) {
                 </svg>
                 <div style="font-size: 12px; color: ${colors.text}; flex: 1; min-width: 0; line-height: 1.4;">
                   ${(() => {
-                    const hasTime = eventData.start?.dateTime || eventData.end?.dateTime;
-                    const startStr = eventData.start?.dateTime ? eventData.start.dateTime.replace('T', ' ').slice(0, 16) : eventData.start?.date || '';
-                    const endStr = eventData.end?.dateTime ? eventData.end.dateTime.replace('T', ' ').slice(0, 16) : eventData.end?.date || '';
-                    if (hasTime) {
-                      return `<div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${startStr}${endStr ? ' ~' : ''}</div>${endStr ? `<div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${endStr}</div>` : ''}`;
-                    } else {
-                      return `<div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${startStr}${endStr ? ` ~ ${endStr}` : ''}</div>`;
-                    }
-                  })()}
+        const hasTime = eventData.start?.dateTime || eventData.end?.dateTime;
+        const startStr = eventData.start?.dateTime ? eventData.start.dateTime.replace('T', ' ').slice(0, 16) : eventData.start?.date || '';
+        const endStr = eventData.end?.dateTime ? eventData.end.dateTime.replace('T', ' ').slice(0, 16) : eventData.end?.date || '';
+        if (hasTime) {
+          return `<div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${startStr}${endStr ? ' ~' : ''}</div>${endStr ? `<div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${endStr}</div>` : ''}`;
+        } else {
+          return `<div style="overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">${startStr}${endStr ? ` ~ ${endStr}` : ''}</div>`;
+        }
+      })()}
                 </div>
               </div>
               ${eventData.location ? `
@@ -317,9 +317,9 @@ function displayResult(data) {
       </div>
     `;
   });
-  
+
   resultContent.innerHTML = eventsHtml;
-  
+
   const dropdownControllers = new Map();
   let activeDropdownIndex = null;
 
@@ -328,7 +328,7 @@ function displayResult(data) {
     const dropdown = resultContent.querySelector(`#tk-dropdown-${index}`);
     const addBtn = resultContent.querySelector(`#tk-add-btn-${index}`);
     let dropdownOpen = false;
-    
+
     if (!card || !dropdown || !addBtn) return;
 
     const openDropdown = async () => {
@@ -428,7 +428,7 @@ function displayResult(data) {
     };
 
     dropdownControllers.set(index, { close: closeDropdown, isOpen: () => dropdownOpen });
-    
+
     card.addEventListener('click', async (e) => {
       if (e.target.closest(`#tk-add-btn-${index}`) || (isCreatingEvent && creatingEventIndex === index)) return;
       if (!dropdownOpen) {
@@ -440,7 +440,7 @@ function displayResult(data) {
         await closeDropdown();
       }
     });
-    
+
     addBtn.addEventListener('click', (e) => { e.stopPropagation(); handleAddEvent(addBtn, index); });
   });
 }
@@ -453,7 +453,7 @@ async function showDropdownForm(originData, eventIndex) {
 
   const settings = await chrome.storage.sync.get(['settings']);
   const colors = getColors();
-  
+
   dropdown.innerHTML = `
     <form id="editForm" style="all: initial !important; display: block !important; background: ${colors.formBg} !important; padding: 16px !important; border-radius: 12px !important; border: none !important; text-align: left !important; margin: 0 !important; box-shadow: 0 -4px 12px rgba(0,0,0,0.08) !important; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif !important; font-size: 14px !important; line-height: 1.5 !important;">
         <div style="all: initial !important; display: block !important; margin-bottom: 8px !important;">
@@ -482,31 +482,31 @@ async function showDropdownForm(originData, eventIndex) {
       </button>
       </form>
   `;
-  
+
   dropdown.querySelector('#tk-dropdown-save').addEventListener('click', async () => {
     if (isCreatingEvent && creatingEventIndex === eventIndex) return;
-    
+
     const startValue = dropdown.querySelector('#editStart').value;
     const endValue = dropdown.querySelector('#editEnd').value;
-    
+
     // 원본이 date 타입이었는지 dateTime 타입이었는지 확인
     const wasStartDate = originData.start?.date && !originData.start?.dateTime;
     const wasEndDate = originData.end?.date && !originData.end?.dateTime;
-    
+
     const updatedEvent = {
       ...originData,
       summary: dropdown.querySelector('#editSummary').value,
-      start: wasStartDate 
+      start: wasStartDate
         ? { date: startValue.split('T')[0], timeZone: originData.start.timeZone }  // date만 저장
         : { dateTime: startValue, timeZone: originData.start.timeZone },          // dateTime 저장
-      end: wasEndDate 
+      end: wasEndDate
         ? { date: endValue.split('T')[0], timeZone: originData.end.timeZone }     // date만 저장
         : { dateTime: endValue, timeZone: originData.end.timeZone },              // dateTime 저장
       location: dropdown.querySelector('#editLocation').value,
       description: dropdown.querySelector('#editDescription').value,
     };
     lastParsedData[eventIndex] = updatedEvent;
-    
+
     updateSaveButtonState(dropdown.querySelector('#tk-dropdown-save'), 'loading');
     await handleAddEvent(modalInstance.querySelector(`#tk-add-btn-${eventIndex}`), eventIndex, dropdown.querySelector('#tk-dropdown-save'));
   });
@@ -603,40 +603,40 @@ async function handleAddEvent(addBtn, eventIndex, saveBtn = null) {
   if (isCreatingEvent) return;
   const isLoggedIn = await checkLoginStatus();
   if (!isLoggedIn) { await showLoginPromptModal(); return; }
-  
+
   isCreatingEvent = true;
   creatingEventIndex = eventIndex;
   addBtn.innerHTML = `<img src="${SHURIKEN_URL}" alt="loading" style="width: 16.2px; height: 16.2px; animation: spin 0.7s linear infinite;">`;
   addBtn.disabled = true;
-  
+
   try {
     const eventData = { ...lastParsedData[eventIndex] };
     const settings = await chrome.storage.sync.get(['settings']);
-    
+
     // 항상 Schedule Ninja snagged 포함
     if (pageInfo) {
       let sourceText = '🥷 Schedule Ninja snagged';
-      
+
       // 설정이 켜져 있으면 페이지 URL도 추가
       if (settings.settings?.showSourceInfo) {
         sourceText += `\n🌐 ${pageInfo.url}`;
       }
-      
-      eventData.description = eventData.description 
-        ? `${eventData.description}\n\n---\n${sourceText}` 
+
+      eventData.description = eventData.description
+        ? `${eventData.description}\n\n---\n${sourceText}`
         : sourceText;
     }
-    
+
     const response = await chrome.runtime.sendMessage({ action: 'createCalendarEvent', eventData: eventData });
-    
+
     if (response.success) {
       console.log('✅ 일정 생성 성공! 링크:', response.event.htmlLink);
       addBtn.innerHTML = `<svg width="20" height="20" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>`;
       addBtn.setAttribute('data-added', 'true');
-      
+
       // 성공 토스트 메시지에 링크 추가 (선택사항)
       showToastMessage(`일정이 추가되었습니다. <a href="${response.event.htmlLink}" target="_blank" style="color: white; text-decoration: underline;">확인하기</a>`);
-      
+
       if (saveBtn) updateSaveButtonState(saveBtn, 'success');
       if (lastParsedData.every((_, i) => modalInstance.querySelector(`#tk-add-btn-${i}`)?.getAttribute('data-added') === 'true')) {
         setTimeout(() => closeModal(), 1500);
@@ -664,10 +664,10 @@ function showToastMessage(message, type = "success") {
   if (!modalContent) return;
 
   const toast = document.createElement('div');
-  
+
   // 타입별 스타일 설정
   let backgroundColor, iconPath;
-  switch(type) {
+  switch (type) {
     case 'success':
       backgroundColor = '#10b981';
       iconPath = 'M5 13l4 4L19 7';
@@ -684,7 +684,7 @@ function showToastMessage(message, type = "success") {
       backgroundColor = '#10b981';
       iconPath = 'M5 13l4 4L19 7';
   }
-  
+
   toast.style.cssText = `
     position: absolute;
     bottom: 12px;
@@ -703,14 +703,14 @@ function showToastMessage(message, type = "success") {
     background: ${backgroundColor};
     color: white;
   `;
-  
+
   toast.innerHTML = `
     <svg width="16" height="16" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="${iconPath}"></path>
     </svg>
     <span>${message}</span>
   `;
-  
+
   modalContent.appendChild(toast);
 
   // 애니메이션
@@ -739,7 +739,7 @@ async function showModal(selectedText, isAutoDetected = false) {
   openModal();
   const loadingIndicator = modalInstance.querySelector('#schedule-ninja-loading');
   const resultContent = modalInstance.querySelector('#schedule-ninja-result-content');
-  
+
   if (loadingIndicator) {
     loadingIndicator.style.display = 'block';
     if (isAutoDetected) {
@@ -752,7 +752,7 @@ async function showModal(selectedText, isAutoDetected = false) {
   const closeHandler = () => closeModal();
   modalInstance.querySelector('#modal-close')?.addEventListener('click', closeHandler);
   modalInstance.querySelector('#modal-backdrop')?.addEventListener('click', closeHandler);
-  
+
   const escapeHandler = (e) => {
     if (e.key === 'Escape') {
       closeHandler();
@@ -764,7 +764,7 @@ async function showModal(selectedText, isAutoDetected = false) {
   pageInfo = { title: document.title, url: window.location.href, domain: window.location.hostname, isAutoDetected };
 
   const response = await chrome.runtime.sendMessage({ action: 'parseText', eventData: { selectedText, pageInfo } });
-  
+
   if (response?.success) {
     displayResult(response.eventData);
     if (isAutoDetected) {
@@ -838,7 +838,7 @@ class BookingPageDetector {
       ...this.dateDetailPatterns,
       ...this.timeDetailPatterns
     ];
-    
+
     this.locationPatterns = [
       /장소|공연장|극장|영화관|홀|아트홀|문화센터/i,
       /venue|location|place|theater|hall|stadium|cinema/i,
@@ -849,17 +849,17 @@ class BookingPageDetector {
       /예매|예약|예약번호|예약정보|티켓|좌석|등급|발권/i,
       /booking|reservation|ticket|seat|grade|reference|confirmation\s?(number|code)?/i
     ];
-    
+
     this.init();
   }
-  
+
   async init() {
     await this.loadSettings();
-    
+
     setTimeout(() => {
       this.checkForBookingPage();
     }, 2000);
-    
+
     let lastUrl = location.href;
     new MutationObserver(() => {
       const url = location.href;
@@ -871,7 +871,7 @@ class BookingPageDetector {
       }
     }).observe(document, { subtree: true, childList: true });
   }
-  
+
   loadSettings() {
     return new Promise(resolve => {
       chrome.storage.sync.get(['settings'], (result) => {
@@ -882,7 +882,7 @@ class BookingPageDetector {
       });
     });
   }
-  
+
   async checkForBookingPage() {
     if (!this.enabled) return;
 
@@ -925,15 +925,15 @@ class BookingPageDetector {
       console.log('⚠️ Confirmation found, but missing required event details (event type + date/time). Skipping.');
     }
   }
-  
+
   setEnabled(enabled) {
     this.enabled = enabled;
     console.log('Auto-detect setting changed:', enabled ? 'On' : 'Off');
   }
-  
+
   extractBookingInfo() {
     const extractedText = this.findBookingInfo();
-    
+
     if (extractedText) {
       console.log('Extracted booking info:', extractedText);
       setTimeout(() => {
@@ -941,7 +941,7 @@ class BookingPageDetector {
       }, 1500);
     }
   }
-  
+
   findBookingInfo() {
     const selectors = [
       '.booking-info, .reservation-info, .ticket-info',
@@ -950,10 +950,10 @@ class BookingPageDetector {
       '.venue, .location, .place',
       'div, p, span, td, li'
     ];
-    
+
     let bestMatch = '';
     let maxScore = 0;
-    
+
     selectors.forEach(selector => {
       const elements = document.querySelectorAll(selector);
       elements.forEach(element => {
@@ -967,11 +967,11 @@ class BookingPageDetector {
         }
       });
     });
-    
+
     return maxScore > 5 ? bestMatch : null;  // Increased from 3 to 5
   }
-  
-  
+
+
   calculateRelevanceScore(text) {
     let score = 0;
     // Increased weights for critical patterns
@@ -983,17 +983,21 @@ class BookingPageDetector {
     this.bookingHintPatterns.forEach(p => { if (p.test(text)) score += 0.5; });  // Reduced from 1
     return score;
   }
-  
+
   showSoftNotificationWithParsing(extractedText) {
     this.createSoftNotificationWithParsing(extractedText);
   }
-  
+
   createSoftNotificationWithParsing(extractedText) {
     const existingNotification = document.getElementById('booking-detection-notification');
     if (existingNotification) {
       existingNotification.remove();
     }
-    
+
+    // 고유한 파서 ID 생성 (취소 기능용)
+    this.currentParserId = `parser_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    console.log(`🔖 [자동감지] 파서 ID 생성: ${this.currentParserId}`);
+
     const notification = document.createElement('div');
     notification.id = 'booking-detection-notification';
     notification.style.cssText = `
@@ -1016,7 +1020,7 @@ class BookingPageDetector {
       transform: translateX(100%);
       opacity: 0;
     `;
-    
+
     notification.innerHTML = `
       <div style="display: flex; align-items: center; gap: 12px;">
         <div id="notification-icon" style="width: 40px; height: 40px; background: linear-gradient(135deg, #E83941, #d32f2f); border-radius: 50% !important; display: flex; align-items: center; justify-content: center;">
@@ -1038,36 +1042,42 @@ class BookingPageDetector {
         </button>
       </div>
     `;
-    
+
     document.body.appendChild(notification);
-    
+
     setTimeout(() => {
       notification.style.transform = 'translateX(0)';
       notification.style.opacity = '1';
     }, 10);
-    
-    this.startBackgroundParsing(extractedText, notification);
-    
+
+    this.startBackgroundParsing(extractedText, notification, this.currentParserId);
+
     const closeBtn = notification.querySelector('#close-soft-notification');
     closeBtn.addEventListener('click', (e) => {
       e.stopPropagation();
+      // 파싱 취소 메시지 전송
+      if (this.currentParserId) {
+        console.log(`🚫 [자동감지] 파싱 취소 요청: ${this.currentParserId}`);
+        chrome.runtime.sendMessage({ action: 'cancelParsing', parserId: this.currentParserId });
+        this.currentParserId = null;
+      }
       this.hideSoftNotification();
     });
-    
+
     notification.addEventListener('click', () => {
       if (this.parsedData) {
         this.hideSoftNotification();
         this.showParsedModal();
       }
     });
-    
+
     setTimeout(() => {
       this.hideSoftNotification();
     }, 15000);
   }
-  
-  
-  startBackgroundParsing(extractedText, notification) {
+
+
+  startBackgroundParsing(extractedText, notification, parserId) {
     const pageInfo = {
       title: document.title,
       url: window.location.href,
@@ -1075,9 +1085,9 @@ class BookingPageDetector {
       isAutoDetected: true
     };
 
-    console.log('🔄 [자동감지] 백그라운드 파싱 시작');
+    console.log('🔄 [자동감지] 백그라운드 파싱 시작, parserId:', parserId);
     chrome.runtime.sendMessage(
-      { action: 'parseText', eventData: { selectedText: extractedText, pageInfo } },
+      { action: 'parseText', eventData: { selectedText: extractedText, pageInfo, parserId } },
       (response) => {
         console.log('📬 [자동감지] 콜백 호출됨!', response);
         if (chrome.runtime.lastError) {
@@ -1085,7 +1095,7 @@ class BookingPageDetector {
           this.updateNotificationForError(notification, chrome.runtime.lastError.message);
           return;
         }
-        
+
         if (response?.success) {
           console.log('✅ [자동감지] 파싱 성공, 알림 업데이트 시작');
           this.parsedData = response.eventData;
@@ -1103,9 +1113,9 @@ class BookingPageDetector {
     console.log('🎉 [자동감지] updateNotificationForSuccess 호출됨', notification);
     const icon = notification.querySelector('#notification-icon');
     const message = notification.querySelector('#notification-message');
-    
+
     console.log('🔍 [자동감지] icon:', icon, 'message:', message);
-    
+
     if (icon && message) {
       icon.innerHTML = `<svg width="20" height="20" fill="none" stroke="white" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7"></path></svg>`;
       message.innerHTML = `${t('autoDetectCompleteTitle')}<br><span style="color: #10b981; font-weight: 500;">${t('autoDetectCompleteHint')}</span>`;
@@ -1119,7 +1129,7 @@ class BookingPageDetector {
   updateNotificationForError(notification, error) {
     const icon = notification.querySelector('#notification-icon');
     const message = notification.querySelector('#notification-message');
-    
+
     if (icon && message) {
       icon.innerHTML = `<svg width="20" height="20" fill="none" stroke="white" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path></svg>`;
       message.innerHTML = `${t('autoDetectFailTitle')}<br><span style="color: #E83941; font-weight: 500;">${t('autoDetectFailHint')}</span>`;
@@ -1135,7 +1145,7 @@ class BookingPageDetector {
       console.error('❌ [자동감지] parsedData가 없어서 모달을 열 수 없음');
     }
   }
-  
+
   showModalWithPreParsedData() {
     openModal();
     const loadingIndicator = modalInstance.querySelector('#schedule-ninja-loading');
@@ -1146,7 +1156,7 @@ class BookingPageDetector {
     const closeHandler = () => closeModal();
     modalInstance.querySelector('#modal-close').addEventListener('click', closeHandler);
     modalInstance.querySelector('#modal-backdrop').addEventListener('click', closeHandler);
-    
+
     const escapeHandler = (e) => {
       if (e.key === 'Escape') {
         closeHandler();
@@ -1171,7 +1181,7 @@ class BookingPageDetector {
       }, 300);
     }
   }
-  
+
   showAutoRecommendation(extractedText) {
     if (modalInstance && modalInstance.style.display !== 'none') return;
     showModal(extractedText, true);
@@ -1189,17 +1199,17 @@ const bookingDetector = new BookingPageDetector();
 // 진행률 업데이트 함수
 function updateProgress(progress, stage) {
   if (!modalInstance) return;
-  
+
   const progressContainer = modalInstance.querySelector('#progress-container');
   const progressBar = modalInstance.querySelector('#progress-bar');
   const progressText = modalInstance.querySelector('#progress-text');
   const loadingText = modalInstance.querySelector('#loading-text');
-  
+
   if (progressContainer && progressBar && progressText) {
     // 진행률 표시 활성화
     progressContainer.style.display = 'block';
     progressBar.style.width = `${progress}%`;
-    
+
     // 단계별 메시지
     const stageMessages = {
       'cache_check': t('progressCacheCheck'),
@@ -1208,12 +1218,12 @@ function updateProgress(progress, stage) {
       'processing': t('progressProcessing'),
       'complete': t('progressComplete')
     };
-    
+
     const message = stageMessages[stage] || t('progressDefault');
     // 괄호 안의 내용 제거 (간결하게 표시)
     const shortMessage = message.replace(/\s*\([^)]*\)/g, '').trim();
     progressText.innerHTML = `${Math.round(progress)}% - ${shortMessage.replace(/\n/g, '<br>')}`;
-    
+
     // 로딩 텍스트 업데이트
     if (loadingText) {
       loadingText.textContent = shortMessage;
@@ -1229,13 +1239,13 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
       const lang = settings.language || (navigator.language.startsWith('ko') ? 'ko' : 'en');
       await loadI18nMessages(lang);
       showModal(request.selectedText);
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else if (request.action === 'closeModal') {
       closeModal();
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else if (request.action === 'updateAutoDetectSetting') {
       if (bookingDetector) bookingDetector.setEnabled(request.enabled);
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else if (request.action === 'updateDarkMode') {
       isDarkMode = request.enabled;
       if (modalInstance && modalInstance.style.display !== 'none') {
@@ -1248,7 +1258,7 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           }
         }, 350);
       }
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else if (request.action === 'updateLanguage') {
       await loadI18nMessages(request.language);
       if (modalInstance && modalInstance.style.display !== 'none') {
@@ -1264,18 +1274,18 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
           }
         }, 350);
       }
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else if (request.action === 'updateProgress') {
       updateProgress(request.progress, request.stage);
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else if (request.action === 'testModal') {
       const settings = await new Promise(resolve => chrome.storage.sync.get('settings', res => resolve(res.settings || {})));
       const lang = settings.language || (navigator.language.startsWith('ko') ? 'ko' : 'en');
       await loadI18nMessages(lang);
       // ... (rest of testModal logic)
-      sendResponse({status: "ok"});
+      sendResponse({ status: "ok" });
     } else {
-      sendResponse({status: "unknown action"});
+      sendResponse({ status: "unknown action" });
     }
   })();
   return true;
@@ -1283,10 +1293,10 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 
 // 초기 설정 로드
 (async () => {
-    const settings = await new Promise(resolve => {
-        chrome.storage.sync.get(['settings'], result => resolve(result.settings || {}));
-    });
-    isDarkMode = settings.darkMode || false;
-    const lang = settings.language || (navigator.language.startsWith('ko') ? 'ko' : 'en');
-    await loadI18nMessages(lang);
+  const settings = await new Promise(resolve => {
+    chrome.storage.sync.get(['settings'], result => resolve(result.settings || {}));
+  });
+  isDarkMode = settings.darkMode || false;
+  const lang = settings.language || (navigator.language.startsWith('ko') ? 'ko' : 'en');
+  await loadI18nMessages(lang);
 })();

--- a/content.js
+++ b/content.js
@@ -938,7 +938,7 @@ class BookingPageDetector {
       console.log('Extracted booking info:', extractedText);
       setTimeout(() => {
         this.showSoftNotificationWithParsing(extractedText);
-      }, 1500);
+      }, 500);  // Reduced from 1500ms for faster UX
     }
   }
 
@@ -968,7 +968,7 @@ class BookingPageDetector {
       });
     });
 
-    return maxScore > 5 ? bestMatch : null;  // Increased from 3 to 5
+    return maxScore > 5 ? bestMatch : null;  // Threshold: 5
   }
 
 


### PR DESCRIPTION
## 변경 사항

### 파서 취소 기능 (PR #34 대체)
- `activeParsers` 맵으로 진행 중인 파싱 세션 추적
- 닫기(X) 버튼 클릭 시 `cancelParsing` 메시지로 세션 즉시 종료
- `parserId`로 세션 식별 및 안전한 종료 처리
- 취소된 세션은 `PARSER_CANCELLED` 에러로 처리

### UX 개선
- 토스트 표시 지연 1.5초 → 500ms로 단축

## 구현 내용

### background.js
- `activeParsers` 전역 Map 추가
- `parseTextWithLLM`에서 세션 등록/삭제 로직
- `cancelParsing` 액션 핸들러 추가

### content.js
- `createSoftNotificationWithParsing`에서 고유 `parserId` 생성
- 닫기 버튼 클릭 시 취소 메시지 전송
- `startBackgroundParsing`에 `parserId` 파라미터 추가

## 테스트 결과
✅ 닫기 버튼 클릭 시 파싱 즉시 취소됨
✅ 콘솔에서 취소 로그 정상 확인

## 관련 이슈
Closes #38